### PR TITLE
feat(waypoint): add notes, pod_method, pod_required and time window attributes

### DIFF
--- a/addon/models/waypoint.js
+++ b/addon/models/waypoint.js
@@ -21,4 +21,13 @@ export default class WaypointModel extends PlaceModel {
     @attr('string') status_code;
     @attr('string') type;
     @attr('number') order;
+    // Orchestrator time windows
+    @attr('date') time_window_start;
+    @attr('date') time_window_end;
+    @attr('number') service_time;
+    // Per-stop POD and notes (mirrors order-level fields;
+    // used as fallback until per-waypoint POD is implemented in driver app)
+    @attr('string') notes;
+    @attr('string') pod_method;
+    @attr('boolean') pod_required;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fleetbase/fleetops-data",
-    "version": "0.1.25",
+    "version": "0.1.27",
     "description": "Fleetbase Fleet-Ops based models, serializers, transforms, adapters and GeoJson utility functions.",
     "keywords": [
         "fleetbase-data",


### PR DESCRIPTION
## Summary

Adds per-stop POD and notes columns to the `Waypoint` Ember Data model, mirroring the equivalent fields on the `Order` model.

### New attributes

| Attribute | Type | Description |
|-----------|------|-------------|
| `notes` | `string` | Free-text driver instructions for this specific stop |
| `pod_method` | `string` | POD method (e.g. `signature`, `photo`, `scan`) |
| `pod_required` | `boolean` | Whether POD must be collected at this stop |
| `time_window_start` | `date` | Earliest acceptable arrival datetime |
| `time_window_end` | `date` | Latest acceptable arrival datetime |
| `service_time` | `number` | Expected dwell time in seconds |

### Notes

- Until per-waypoint POD is fully implemented in the driver app, the order-level `pod_method` / `pod_required` values are used as a fallback.
- The corresponding server-side migration and model/resource changes are in `fleetbase/fleetops` `dev-v0.6.39`.