### PR TITLE
feat: add orchestrator capacity and constraint fields to Vehicle and Order models

### DIFF
--- a/addon/models/order.js
+++ b/addon/models/order.js
@@ -94,6 +94,12 @@ export default class OrderModel extends Model {
     @attr('raw') tracker_data;
     @attr('raw') eta;
 
+    /** Orchestrator constraints */
+    @attr('date') time_window_start;
+    @attr('date') time_window_end;
+    @attr('raw') required_skills;
+    @attr('number') orchestrator_priority;
+
     /** @dates */
     @attr('date') scheduled_at;
     @attr('date') dispatched_at;

--- a/addon/models/vehicle.js
+++ b/addon/models/vehicle.js
@@ -98,10 +98,20 @@ export default class VehicleModel extends Model {
     @attr('number') height;
     @attr('number') towing_capacity;
     @attr('number') payload_capacity;
+    @attr('number') payload_capacity_volume;
+    @attr('number') payload_capacity_pallets;
+    @attr('number') payload_capacity_parcels;
     @attr('number') seating_capacity;
     @attr('number') ground_clearance;
     @attr('number') bed_length;
     @attr('number') fuel_capacity;
+
+    /** Orchestrator constraints */
+    @attr('raw') skills;
+    @attr('number') max_tasks;
+    @attr('string') time_window_start;
+    @attr('string') time_window_end;
+    @attr('boolean') return_to_depot;
 
     /** Regulatory / compliance */
     @attr('string') emission_standard;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fleetbase/fleetops-data",
-    "version": "0.1.27",
+    "version": "0.1.28",
     "description": "Fleetbase Fleet-Ops based models, serializers, transforms, adapters and GeoJson utility functions.",
     "keywords": [
         "fleetbase-data",


### PR DESCRIPTION
## Summary

Adds missing Ember Data model attributes for orchestrator capacity and constraint fields, aligned with the server-side fixes in fleetbase/fleetops#225.

### Vehicle model
- Added `payload_capacity_volume`, `payload_capacity_pallets`, `payload_capacity_parcels` (following the `payload_capacity_*` naming convention; `payload_capacity` was already present)
- Added orchestrator constraint fields: `skills` (raw), `max_tasks` (number), `time_window_start` (string), `time_window_end` (string), `return_to_depot` (boolean)

### Order model
- Added orchestrator constraint fields: `time_window_start` (date), `time_window_end` (date), `required_skills` (raw), `orchestrator_priority` (number)

### Entity model
- Already has `weight`, `weight_unit`, `length`, `width`, `height`, `dimensions_unit` — no changes needed

### Related
- Server-side fix: fleetbase/fleetops#225