### PR TITLE
Add recurring series model fields

### DIFF
--- a/addon/models/order.js
+++ b/addon/models/order.js
@@ -29,6 +29,7 @@ export default class OrderModel extends Model {
     @attr('string') payload_id;
     @attr('string') purchase_rate_id;
     @attr('string') driver_id;
+    @attr('string') recurring_order_schedule_uuid;
 
     /** @relationships */
     @belongsTo('company') company;
@@ -43,6 +44,7 @@ export default class OrderModel extends Model {
     @belongsTo('route', { async: false }) route;
     @belongsTo('purchase-rate', { async: false }) purchase_rate;
     @belongsTo('tracking-number', { async: false }) tracking_number;
+    @belongsTo('recurring-order-schedule', { async: false, inverse: null }) recurring_order_schedule;
     @hasMany('tracking-status', { async: false }) tracking_statuses;
     @hasMany('comment', { async: false }) comments;
     @hasMany('file', { async: false }) files;
@@ -92,6 +94,7 @@ export default class OrderModel extends Model {
     @attr('boolean') started;
     @attr('boolean') adhoc;
     @attr('boolean') is_route_optimized;
+    @attr('boolean') is_recurring_generated;
     @attr('boolean') customer_is_contact;
     @attr('boolean') customer_is_vendor;
     @attr('boolean') facilitator_is_contact;
@@ -109,6 +112,7 @@ export default class OrderModel extends Model {
 
     /** @dates */
     @attr('date') scheduled_at;
+    @attr('date') recurring_occurrence_at;
     @attr('date') dispatched_at;
     @attr('date') started_at;
     @attr('date') deleted_at;

--- a/addon/models/recurring-order-schedule.js
+++ b/addon/models/recurring-order-schedule.js
@@ -25,6 +25,7 @@ export default class RecurringOrderScheduleModel extends Model {
     @attr('raw') template_entities;
     @attr('raw') meta;
     @attr('raw') upcoming_occurrences;
+    @attr('raw') history_occurrences;
     @attr('date') next_occurrence_at;
     @attr('date') created_at;
     @attr('date') updated_at;

--- a/addon/models/recurring-order-schedule.js
+++ b/addon/models/recurring-order-schedule.js
@@ -20,6 +20,13 @@ export default class RecurringOrderScheduleModel extends Model {
     @attr('string') driver_assigned_uuid;
     @attr('string') vehicle_assigned_uuid;
     @attr('string') service_rate_uuid;
+    @attr('string') customer_name;
+    @attr('string') facilitator_name;
+    @attr('string') order_config_name;
+    @attr('string') driver_assigned_name;
+    @attr('string') vehicle_assigned_name;
+    @attr('string') service_rate_name;
+    @attr('number') generated_orders_count;
     @attr('raw') template_order_meta;
     @attr('raw') template_payload;
     @attr('raw') template_entities;

--- a/addon/serializers/order.js
+++ b/addon/serializers/order.js
@@ -24,6 +24,7 @@ export default class OrderSerializer extends ApplicationSerializer.extend(Embedd
             files: { embedded: 'always' },
             comments: { embedded: 'always' },
             custom_field_values: { embedded: 'always' },
+            recurring_order_schedule: { embedded: 'always' },
         };
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fleetbase/fleetops-data",
-    "version": "0.1.32",
+    "version": "0.1.33",
     "description": "Fleetbase Fleet-Ops based models, serializers, transforms, adapters and GeoJson utility functions.",
     "keywords": [
         "fleetbase-data",


### PR DESCRIPTION
## Summary
- Bumps @fleetbase/fleetops-data to 0.1.33.
- Adds recurring series linkage fields to the order model.
- Adds history occurrences to recurring order schedules.

## Why
FleetOps consumes these fields for the recurring series UX, and the model definitions belong in fleetops-data instead of the FleetOps engine.

## Validation
- ./node_modules/.bin/eslint addon/models/order.js addon/models/recurring-order-schedule.js
- git diff --check