### PR TITLE
Default driver and vehicle statuses to available

### DIFF
--- a/addon/models/driver.js
+++ b/addon/models/driver.js
@@ -60,7 +60,7 @@ export default class DriverModel extends Model {
     @attr('number') heading;
     @attr('string') country;
     @attr('string') city;
-    @attr('string') status;
+    @attr('string', { defaultValue: 'available' }) status;
     @attr('boolean') online;
     @attr('raw') meta;
 

--- a/addon/models/vehicle.js
+++ b/addon/models/vehicle.js
@@ -144,7 +144,7 @@ export default class VehicleModel extends Model {
 
     /** Misc text / meta */
     @attr('string') notes;
-    @attr('string') status;
+    @attr('string', { defaultValue: 'available' }) status;
     @attr('string') slug;
     @attr('boolean') online;
     @attr('raw') vin_data;


### PR DESCRIPTION
## Summary
- default FleetOps Data driver status to available
- keep vehicle model status defaulted to available

## Verification
- ./node_modules/.bin/eslint addon/models/driver.js addon/models/vehicle.js
- git diff --check