### PR TITLE
fix: preserve selected geography type on rate fees

### DIFF
--- a/addon/models/service-rate-fee.js
+++ b/addon/models/service-rate-fee.js
@@ -73,7 +73,11 @@ export default class ServiceRateFeeModel extends Model {
         return formatDate(this.created_at, 'dd, MMM');
     }
 
-    @computed('is_fallback', 'zone_uuid', 'service_area_uuid', 'zone.id', 'service_area.id') get geography_type() {
+    @computed('selected_geography_type', 'is_fallback', 'zone_uuid', 'service_area_uuid', 'zone.id', 'service_area.id') get geography_type() {
+        if (this.selected_geography_type) {
+            return this.selected_geography_type;
+        }
+
         if (this.is_fallback) {
             return 'fallback';
         }

--- a/tests/unit/models/service-rate-fee-test.js
+++ b/tests/unit/models/service-rate-fee-test.js
@@ -11,4 +11,32 @@ module('Unit | Model | service rate fee', function (hooks) {
         let model = store.createRecord('service-rate-fee', {});
         assert.ok(model);
     });
+
+    test('geography type prefers transient selected geography type', function (assert) {
+        let store = this.owner.lookup('service:store');
+        let model = store.createRecord('service-rate-fee', {
+            service_area_uuid: 'service_area_1',
+        });
+
+        model.set('selected_geography_type', 'zone');
+
+        assert.strictEqual(model.geography_type, 'zone');
+    });
+
+    test('geography type derives from saved relationships when no transient type is selected', function (assert) {
+        let store = this.owner.lookup('service:store');
+        let zoneRule = store.createRecord('service-rate-fee', {
+            zone_uuid: 'zone_1',
+        });
+        let serviceAreaRule = store.createRecord('service-rate-fee', {
+            service_area_uuid: 'service_area_1',
+        });
+        let fallbackRule = store.createRecord('service-rate-fee', {
+            is_fallback: true,
+        });
+
+        assert.strictEqual(zoneRule.geography_type, 'zone');
+        assert.strictEqual(serviceAreaRule.geography_type, 'service_area');
+        assert.strictEqual(fallbackRule.geography_type, 'fallback');
+    });
 });


### PR DESCRIPTION
## Summary
- prefer transient selected geography type when deriving service-rate fee geography_type
- keep persisted geography contract unchanged for zone, service area, and fallback rules
- add model coverage for transient and relationship-derived geography types

## Validation
- PATH=/opt/homebrew/bin:$PATH pnpm exec eslint addon/models/service-rate-fee.js tests/unit/models/service-rate-fee-test.js
- PATH=/opt/homebrew/bin:$PATH pnpm exec ember test --filter "Unit | Model | service rate fee" *(build succeeded; browser test load failed because vendor.js could not resolve @ember/string from @ember-data/store)*
- git diff --check

## Notes
- This is a frontend model contract fix only. It does not change serialized API fields or persistence behavior.