### PR TITLE
Add fuel provider data models

### DIFF
--- a/addon/models/fuel-provider-connection.js
+++ b/addon/models/fuel-provider-connection.js
@@ -1,0 +1,51 @@
+import Model, { attr, hasMany } from '@ember-data/model';
+import { computed } from '@ember/object';
+import { format as formatDate, isValid as isValidDate, formatDistanceToNow } from 'date-fns';
+
+export default class FuelProviderConnectionModel extends Model {
+    @attr('string') public_id;
+    @attr('string') company_uuid;
+    @attr('string') provider;
+    @attr('string') name;
+    @attr('string', { defaultValue: 'production' }) environment;
+    @attr('string', { defaultValue: 'configured' }) status;
+    @attr('raw') sync_settings;
+    @attr('raw') last_sync_state;
+    @attr('string') last_error;
+    @attr('raw') meta;
+
+    @hasMany('fuel-provider-transaction') transactions;
+
+    @attr('date') last_synced_at;
+    @attr('date') last_tested_at;
+    @attr('date') created_at;
+    @attr('date') updated_at;
+
+    @computed('provider', 'name') get displayName() {
+        return this.name || this.provider;
+    }
+
+    @computed('last_synced_at') get lastSyncedAt() {
+        return this.formatDate(this.last_synced_at);
+    }
+
+    @computed('last_tested_at') get lastTestedAt() {
+        return this.formatDate(this.last_tested_at);
+    }
+
+    @computed('updated_at') get updatedAgo() {
+        if (!isValidDate(this.updated_at)) {
+            return null;
+        }
+
+        return formatDistanceToNow(this.updated_at);
+    }
+
+    formatDate(value) {
+        if (!isValidDate(value)) {
+            return null;
+        }
+
+        return formatDate(value, 'yyyy-MM-dd HH:mm');
+    }
+}

--- a/addon/models/fuel-provider-transaction.js
+++ b/addon/models/fuel-provider-transaction.js
@@ -1,0 +1,60 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+import { computed } from '@ember/object';
+import { format as formatDate, isValid as isValidDate } from 'date-fns';
+
+export default class FuelProviderTransactionModel extends Model {
+    @attr('string') public_id;
+    @attr('string') company_uuid;
+    @attr('string') fuel_provider_connection_uuid;
+    @attr('string') fuel_report_uuid;
+    @attr('string') fuel_report_id;
+    @attr('string') vehicle_uuid;
+    @attr('string') driver_uuid;
+    @attr('string') order_uuid;
+    @attr('string') provider;
+    @attr('string') provider_transaction_id;
+    @attr('string') provider_vehicle_id;
+    @attr('string') vehicle_card_id;
+    @attr('string') internal_number;
+    @attr('string') structure_number;
+    @attr('string') plate_number;
+    @attr('string') trip_number;
+    @attr('string') station_name;
+    @attr('string') station_latitude;
+    @attr('string') station_longitude;
+    @attr('point') station_location;
+    @attr('date') transaction_at;
+    @attr('string') volume;
+    @attr('string') metric_unit;
+    @attr('string') amount;
+    @attr('string') currency;
+    @attr('string') odometer;
+    @attr('string') sync_status;
+    @attr('date') matched_at;
+    @attr('string') vehicle_name;
+    @attr('string') driver_name;
+    @attr('raw') normalized_payload;
+    @attr('raw') raw_payload;
+    @attr('raw') meta;
+
+    @belongsTo('fuel-provider-connection') connection;
+    @belongsTo('fuel-report') fuel_report;
+    @belongsTo('vehicle') vehicle;
+    @belongsTo('driver') driver;
+    @belongsTo('order') order;
+
+    @attr('date') created_at;
+    @attr('date') updated_at;
+
+    @computed('transaction_at') get transactionAt() {
+        if (!isValidDate(this.transaction_at)) {
+            return null;
+        }
+
+        return formatDate(this.transaction_at, 'yyyy-MM-dd HH:mm');
+    }
+
+    @computed('sync_status') get isMatched() {
+        return this.sync_status === 'matched';
+    }
+}

--- a/addon/models/fuel-report.js
+++ b/addon/models/fuel-report.js
@@ -29,6 +29,9 @@ export default class FuelReportModel extends Model {
     @attr('string') volume;
     @attr('string', { defaultValue: 'L' }) metric_unit;
     @attr('string') status;
+    @attr('string') source;
+    @attr('string') provider;
+    @attr('string') fuel_provider_transaction_uuid;
     @attr('point') location;
     @attr('raw') meta;
 

--- a/addon/serializers/fuel-provider-connection.js
+++ b/addon/serializers/fuel-provider-connection.js
@@ -1,0 +1,4 @@
+import ApplicationSerializer from '@fleetbase/ember-core/serializers/application';
+import { EmbeddedRecordsMixin } from '@ember-data/serializer/rest';
+
+export default class FuelProviderConnectionSerializer extends ApplicationSerializer.extend(EmbeddedRecordsMixin) {}

--- a/addon/serializers/fuel-provider-transaction.js
+++ b/addon/serializers/fuel-provider-transaction.js
@@ -1,0 +1,4 @@
+import ApplicationSerializer from '@fleetbase/ember-core/serializers/application';
+import { EmbeddedRecordsMixin } from '@ember-data/serializer/rest';
+
+export default class FuelProviderTransactionSerializer extends ApplicationSerializer.extend(EmbeddedRecordsMixin) {}

--- a/app/models/fuel-provider-connection.js
+++ b/app/models/fuel-provider-connection.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/fleetops-data/models/fuel-provider-connection';

--- a/app/models/fuel-provider-transaction.js
+++ b/app/models/fuel-provider-transaction.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/fleetops-data/models/fuel-provider-transaction';

--- a/app/serializers/fuel-provider-connection.js
+++ b/app/serializers/fuel-provider-connection.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/fleetops-data/serializers/fuel-provider-connection';

--- a/app/serializers/fuel-provider-transaction.js
+++ b/app/serializers/fuel-provider-transaction.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/fleetops-data/serializers/fuel-provider-transaction';


### PR DESCRIPTION
## Summary
- adds shared FleetOps Data models for fuel provider connections and transactions
- adds serializers for fuel provider resources
- exposes provider metadata on fuel reports

## Validation
- focused FleetOps Data ESLint for the new models and serializers