### PR TITLE
Add facilitator driver model

### DIFF
--- a/addon/models/facilitator-driver.js
+++ b/addon/models/facilitator-driver.js
@@ -1,0 +1,70 @@
+import FacilitatorModel from './facilitator';
+import { attr } from '@ember-data/model';
+import { computed, get } from '@ember/object';
+import config from 'ember-get-config';
+
+export default class FacilitatorDriverModel extends FacilitatorModel {
+    /** @ids */
+    @attr('string') public_id;
+    @attr('string') company_uuid;
+    @attr('string') user_uuid;
+    @attr('string') vehicle_uuid;
+    @attr('string') vendor_uuid;
+    @attr('string') current_job_uuid;
+    @attr('string') photo_uuid;
+    @attr('string') vehicle_id;
+    @attr('string') vendor_id;
+    @attr('string') current_job_id;
+    @attr('string') internal_id;
+
+    /** @attributes */
+    @attr('string') name;
+    @attr('string') phone;
+    @attr('string') email;
+    @attr('string', {
+        defaultValue: get(config, 'defaultValues.driverImage'),
+    })
+    photo_url;
+    @attr('string') vehicle_name;
+    @attr('string', {
+        defaultValue: get(config, 'defaultValues.vehicleAvatar'),
+    })
+    vehicle_avatar;
+    @attr('string') vendor_name;
+    @attr('string') drivers_license_number;
+    @attr('string', {
+        defaultValue: get(config, 'defaultValues.driverAvatar'),
+    })
+    avatar_url;
+    @attr('string') avatar_value;
+    @attr('point') location;
+    @attr('number') heading;
+    @attr('string') country;
+    @attr('string') city;
+    @attr('string', { defaultValue: 'available' }) status;
+    @attr('boolean') online;
+    @attr('raw') meta;
+
+    /** @dates */
+    @attr('date') license_expiry;
+    @attr('date') deleted_at;
+    @attr('date') created_at;
+    @attr('date') updated_at;
+
+    /** @computed */
+    @computed('photo_url') get photoUrl() {
+        if (!this.photo_url) {
+            return get(config, 'defaultValues.driverImage');
+        }
+
+        return this.photo_url;
+    }
+
+    @computed('name', 'public_id') get displayName() {
+        if (!this.name) {
+            return this.public_id;
+        }
+
+        return this.name;
+    }
+}

--- a/addon/models/facilitator.js
+++ b/addon/models/facilitator.js
@@ -20,6 +20,7 @@ export default class FacilitatorModel extends Model {
     @equal('facilitator_type', 'vendor') isVendor;
     @equal('facilitator_type', 'integrated-vendor') isIntegratedVendor;
     @equal('facilitator_type', 'contact') isContact;
+    @equal('facilitator_type', 'driver') isDriver;
 
     @computed('updated_at') get updatedAgo() {
         if (!isValidDate(this.updated_at)) {

--- a/app/models/facilitator-driver.js
+++ b/app/models/facilitator-driver.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/fleetops-data/models/facilitator-driver';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fleetbase/fleetops-data",
-    "version": "0.1.37",
+    "version": "0.1.38",
     "description": "Fleetbase Fleet-Ops based models, serializers, transforms, adapters and GeoJson utility functions.",
     "keywords": [
         "fleetbase-data",

--- a/tests/unit/models/facilitator-driver-test.js
+++ b/tests/unit/models/facilitator-driver-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'dummy/tests/helpers';
+
+module('Unit | Model | facilitator driver', function (hooks) {
+    setupTest(hooks);
+
+    test('it exists', function (assert) {
+        let store = this.owner.lookup('service:store');
+        let model = store.createRecord('facilitator-driver', {
+            name: 'Test Driver',
+            public_id: 'driver_test',
+        });
+
+        assert.ok(model);
+        assert.strictEqual(model.displayName, 'Test Driver');
+    });
+});

--- a/tests/unit/serializers/maintenance-schedule-test.js
+++ b/tests/unit/serializers/maintenance-schedule-test.js
@@ -1,0 +1,37 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'dummy/tests/helpers';
+
+module('Unit | Serializer | maintenance schedule', function (hooks) {
+    setupTest(hooks);
+
+    test('it exists', function (assert) {
+        let store = this.owner.lookup('service:store');
+        let serializer = store.serializerFor('maintenance-schedule');
+
+        assert.ok(serializer);
+    });
+
+    test('it normalizes an embedded facilitator driver default assignee', function (assert) {
+        let store = this.owner.lookup('service:store');
+        let serializer = store.serializerFor('maintenance-schedule');
+        let modelClass = store.modelFor('maintenance-schedule');
+
+        let normalized = serializer.normalize(modelClass, {
+            uuid: 'schedule-1',
+            public_id: 'schedule_1',
+            name: 'Oil Change',
+            default_assignee_uuid: 'driver-1',
+            default_assignee_type: 'fleet-ops:driver',
+            default_assignee: {
+                uuid: 'driver-1',
+                public_id: 'driver_1',
+                type: 'facilitator-driver',
+                facilitator_type: 'driver',
+                name: 'Test Driver',
+            },
+        });
+
+        assert.strictEqual(normalized.data.relationships.default_assignee.data.type, 'facilitator-driver');
+        assert.strictEqual(normalized.data.relationships.default_assignee.data.id, 'driver-1');
+    });
+});


### PR DESCRIPTION
## Summary
- add the missing facilitator-driver Ember Data model
- register the app re-export and driver subtype helper
- add model and maintenance schedule normalization regressions

## Validation
- targeted ESLint passed for touched fleetops-data files
- focused Ember test build succeeded, but Testem failed before assertions because testem requires ESM-only execa from CommonJS in this local harness