### PR TITLE
Add inspection data models

### DIFF
--- a/addon/models/inspection-form.js
+++ b/addon/models/inspection-form.js
@@ -1,0 +1,39 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class InspectionFormModel extends Model {
+    @attr('string') uuid;
+    @attr('string') public_id;
+    @attr('string') company_uuid;
+    @attr('string') subject_uuid;
+    @attr('string') subject_type;
+    @attr('string') name;
+    @attr('string') description;
+    @attr('string') type;
+    @attr('string') status;
+    @attr('string') frequency;
+    @belongsTo('maintenance-subject', { polymorphic: true, async: false }) subject;
+    @attr('raw') items;
+    @attr('raw') settings;
+    @attr('raw') meta;
+    @attr('number') item_count;
+    @attr('boolean') is_published;
+    @attr('date') published_at;
+    @attr('date') created_at;
+    @attr('date') updated_at;
+
+    get displayName() {
+        return this.name || this.public_id;
+    }
+
+    get createdAt() {
+        return this.created_at;
+    }
+
+    get updatedAt() {
+        return this.updated_at;
+    }
+
+    get publishedAt() {
+        return this.published_at;
+    }
+}

--- a/addon/models/inspection-item-result.js
+++ b/addon/models/inspection-item-result.js
@@ -1,0 +1,23 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class InspectionItemResultModel extends Model {
+    @attr('string') uuid;
+    @attr('string') company_uuid;
+    @attr('string') inspection_submission_uuid;
+    @attr('string') issue_uuid;
+    @attr('string') work_order_uuid;
+    @belongsTo('inspection-submission', { async: false, inverse: null }) submission;
+    @belongsTo('issue', { async: false, inverse: null }) issue;
+    @belongsTo('work-order', { async: false, inverse: null }) work_order;
+    @attr('string') item_key;
+    @attr('string') label;
+    @attr('string') category;
+    @attr('string') status;
+    @attr('string') severity;
+    @attr('boolean') passed;
+    @attr('string') comments;
+    @attr('raw') photos;
+    @attr('raw') meta;
+    @attr('date') created_at;
+    @attr('date') updated_at;
+}

--- a/addon/models/inspection-submission.js
+++ b/addon/models/inspection-submission.js
@@ -1,0 +1,61 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class InspectionSubmissionModel extends Model {
+    @attr('string') uuid;
+    @attr('string') public_id;
+    @attr('string') company_uuid;
+    @attr('string') inspection_form_uuid;
+    @attr('string') vehicle_uuid;
+    @attr('string') driver_uuid;
+    @attr('string') submitted_by_uuid;
+    @attr('string') issue_uuid;
+    @attr('string') work_order_uuid;
+    @belongsTo('inspection-form', { async: false, inverse: null }) form;
+    @belongsTo('vehicle', { async: false, inverse: null }) vehicle;
+    @belongsTo('driver', { async: false, inverse: null }) driver;
+    @belongsTo('user', { async: false, inverse: null }) submitted_by;
+    @belongsTo('issue', { async: false, inverse: null }) issue;
+    @belongsTo('work-order', { async: false, inverse: null }) work_order;
+    @attr('raw') item_results;
+    @attr('string') type;
+    @attr('string') status;
+    @attr('string') result;
+    @attr('string') source;
+    @attr('number') odometer;
+    @attr('number') engine_hours;
+    @attr('number') total_items;
+    @attr('number') failed_items;
+    @attr('raw') location;
+    @attr('raw') signature;
+    @attr('raw') attachments;
+    @attr('raw') meta;
+    @attr('string') form_name;
+    @attr('string') vehicle_name;
+    @attr('string') driver_name;
+    @attr('boolean') has_failures;
+    @attr('date') started_at;
+    @attr('date') submitted_at;
+    @attr('date') resolved_at;
+    @attr('date') created_at;
+    @attr('date') updated_at;
+
+    get displayName() {
+        return this.public_id || this.form_name || 'Inspection';
+    }
+
+    get createdAt() {
+        return this.created_at;
+    }
+
+    get updatedAt() {
+        return this.updated_at;
+    }
+
+    get submittedAt() {
+        return this.submitted_at;
+    }
+
+    get resolvedAt() {
+        return this.resolved_at;
+    }
+}

--- a/addon/models/work-order.js
+++ b/addon/models/work-order.js
@@ -19,6 +19,7 @@ export default class WorkOrderModel extends Model {
     /** @attributes */
     @attr('string') code;
     @attr('string') subject;
+    @attr('string') category;
     @attr('string') status;
     @attr('string') priority;
     @attr('string') instructions;

--- a/addon/serializers/inspection-form.js
+++ b/addon/serializers/inspection-form.js
@@ -1,0 +1,16 @@
+import ApplicationSerializer from '@fleetbase/ember-core/serializers/application';
+import { EmbeddedRecordsMixin } from '@ember-data/serializer/rest';
+
+export default class InspectionFormSerializer extends ApplicationSerializer.extend(EmbeddedRecordsMixin) {
+    /**
+     * Embedded relationship attributes
+     *
+     * @var {Object}
+     */
+    get attrs() {
+        return {
+            subject: { embedded: 'always' },
+            custom_field_values: { embedded: 'always' },
+        };
+    }
+}

--- a/addon/serializers/inspection-item-result.js
+++ b/addon/serializers/inspection-item-result.js
@@ -1,0 +1,3 @@
+import ApplicationSerializer from '@fleetbase/ember-core/serializers/application';
+
+export default class InspectionItemResultSerializer extends ApplicationSerializer {}

--- a/addon/serializers/inspection-submission.js
+++ b/addon/serializers/inspection-submission.js
@@ -1,0 +1,22 @@
+import ApplicationSerializer from '@fleetbase/ember-core/serializers/application';
+import { EmbeddedRecordsMixin } from '@ember-data/serializer/rest';
+
+export default class InspectionSubmissionSerializer extends ApplicationSerializer.extend(EmbeddedRecordsMixin) {
+    /**
+     * Embedded relationship attributes
+     *
+     * @var {Object}
+     */
+    get attrs() {
+        return {
+            form: { embedded: 'always' },
+            vehicle: { embedded: 'always' },
+            driver: { embedded: 'always' },
+            submitted_by: { embedded: 'always' },
+            issue: { embedded: 'always' },
+            work_order: { embedded: 'always' },
+            item_results: { embedded: 'always' },
+            custom_field_values: { embedded: 'always' },
+        };
+    }
+}

--- a/app/models/inspection-form.js
+++ b/app/models/inspection-form.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/fleetops-data/models/inspection-form';

--- a/app/models/inspection-item-result.js
+++ b/app/models/inspection-item-result.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/fleetops-data/models/inspection-item-result';

--- a/app/models/inspection-submission.js
+++ b/app/models/inspection-submission.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/fleetops-data/models/inspection-submission';

--- a/app/serializers/inspection-form.js
+++ b/app/serializers/inspection-form.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/fleetops-data/serializers/inspection-form';

--- a/app/serializers/inspection-item-result.js
+++ b/app/serializers/inspection-item-result.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/fleetops-data/serializers/inspection-item-result';

--- a/app/serializers/inspection-submission.js
+++ b/app/serializers/inspection-submission.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/fleetops-data/serializers/inspection-submission';


### PR DESCRIPTION
## Summary
- add shared FleetOps inspection form, submission, and item result Ember Data models
- add serializers for inspection resources and app reexports for host/module reuse
- keep inspection data contracts available through @fleetbase/fleetops-data instead of fleetops-engine-local models
