### PR TITLE
Add is-waypoint-record util (moved from ember-core)

### DIFF
--- a/addon/utils/is-waypoint-record.js
+++ b/addon/utils/is-waypoint-record.js
@@ -1,0 +1,5 @@
+import WaypointModel from '../models/waypoint';
+
+export default function isWaypointRecord(record) {
+    return record instanceof WaypointModel;
+}

--- a/app/utils/is-waypoint-record.js
+++ b/app/utils/is-waypoint-record.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/fleetops-data/utils/is-waypoint-record';

--- a/tests/unit/utils/is-waypoint-record-test.js
+++ b/tests/unit/utils/is-waypoint-record-test.js
@@ -1,0 +1,47 @@
+import isWaypointRecord from 'dummy/utils/is-waypoint-record';
+import WaypointModel from 'dummy/models/waypoint';
+import PlaceModel from 'dummy/models/place';
+import { module, test } from 'qunit';
+import { setupTest } from 'dummy/tests/helpers';
+import ObjectProxy from '@ember/object/proxy';
+
+module('Unit | Utility | is-waypoint-record', function (hooks) {
+    setupTest(hooks);
+
+    hooks.beforeEach(function () {
+        this.store = this.owner.lookup('service:store');
+    });
+
+    test('it returns true for a waypoint record', function (assert) {
+        assert.true(isWaypointRecord(this.store.createRecord('waypoint', {})));
+    });
+
+    test('it returns false for a place, which waypoint extends', function (assert) {
+        // WaypointModel extends PlaceModel, so the check has to be narrow enough
+        // to reject the parent while still accepting the child.
+        assert.true(WaypointModel.prototype instanceof PlaceModel, 'waypoint does extend place');
+        assert.false(isWaypointRecord(this.store.createRecord('place', {})));
+    });
+
+    test('it returns false for an unrelated record', function (assert) {
+        assert.false(isWaypointRecord(this.store.createRecord('order', {})));
+    });
+
+    test('it returns false for a proxy wrapping a waypoint', function (assert) {
+        const record = this.store.createRecord('waypoint', {});
+
+        assert.false(isWaypointRecord(ObjectProxy.create({ content: record })), 'instanceof looks at the proxy, not its content');
+    });
+
+    test('it returns false for plain and nullish values', function (assert) {
+        assert.false(isWaypointRecord({}));
+        assert.false(isWaypointRecord(null));
+        assert.false(isWaypointRecord(undefined));
+        assert.false(isWaypointRecord('waypoint'));
+        assert.false(isWaypointRecord([]));
+    });
+
+    test('it returns false for an object merely shaped like a waypoint', function (assert) {
+        assert.false(isWaypointRecord({ place: {}, order: 1 }), 'the check is by identity, not by shape');
+    });
+});


### PR DESCRIPTION
## Why

`isWaypointRecord` lived in `@fleetbase/ember-core`, where it imported `../models/waypoint` — a path that does not exist in that package. Any consumer importing it got `Could not find module`.

This is its natural home: the `Waypoint` model is here, so the import is a plain relative one.

It could not stay in ember-core. That package cannot depend on `@fleetbase/fleetops-data`, because fleetops-data already depends on `@fleetbase/ember-core` — a direct dependency would be circular. The alternatives were an undeclared cross-package import or an optional peer dependency, both worse than putting the util beside the model it checks.

## Consumer impact

None. No package references it in source — checked across every package in the monorepo. The matches that appear elsewhere are inside built `dist/` bundles, which is ember-core's own code inlined into consumers' vendor files, not real usage.

## Tests

Covers a real waypoint record, the `place` model that waypoint extends (the check has to reject the parent while accepting the child), an unrelated record, an `ObjectProxy` wrapping a waypoint (`instanceof` sees the proxy, not its content), and plain and nullish values.

## Related

Removed from ember-core in https://github.com/fleetbase/ember-core/pull/90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)